### PR TITLE
tartufo.toml: adds support for new exclude entropy patterns syntax

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -172,10 +172,23 @@ function parseTartufoConfig() {
     const patterns: Array<excludedEntropyPattern> = [];
 
     data.tool.tartufo[tartufoExcludeEntropyPatterns].forEach((obj: any) => {
-      patterns.push({
-        path_pattern: obj["path-pattern"],
-        pattern: obj.pattern,
-      });
+      // legacy data format
+      if (typeof obj === "string") {
+        const parts = obj.split("::");
+
+        patterns.push({
+          path_pattern: parts[0],
+          pattern: parts[1],
+        });
+      }
+
+      // modern data format
+      if (obj["path-pattern"] && obj.pattern) {
+        patterns.push({
+          path_pattern: obj["path-pattern"],
+          pattern: obj.pattern,
+        });
+      }
     });
 
     connection.console.log(


### PR DESCRIPTION
This adds support for the new exclude entropy patterns syntax added in [Tartufo v2.9.0](https://github.com/godaddy/tartufo/releases/tag/v2.9.0), the previous syntax should be considered deprecated and will be removed in v3 afaik.